### PR TITLE
Fix wrong namespace in composer.json and enables correct usage with Yii2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,9 @@
     },{
       "name": "machour",
       "email": "machour@gmail.com"
+    },{
+      "name": "Ivo Pereira",
+      "email": "ivoecpereira@gmail.com"
     }
   ],
   "require": {
@@ -25,7 +28,7 @@
   },
   "autoload": {
     "psr-4": {
-      "daveferger\\BotMan\\Cache\\": "src/"
+      "daveferger\\BotMan\\Cache\\": "src/Cache/"
     }
   }
 }


### PR DESCRIPTION
The mentioned namespace in composer.json was wrong and it was making it impossible for Yii2 to find it, when passing it as a Caching mechanism to BotMan instance.

```php
<?php
$config = [ /*...*/ ];
BotManFactory::create($config, new Yii2Cache);
?>
```